### PR TITLE
PR › fix „hassfest“ GH workflow manifest validation err“

### DIFF
--- a/custom_components/rwfc/manifest.json
+++ b/custom_components/rwfc/manifest.json
@@ -4,8 +4,8 @@
   "codeowners": ["@Bitte-ein-Git", "@elias1731"],
   "config_flow": true,
   "documentation": "https://github.com/Bitte-ein-Git/ha_rwfc",
-  "issue_tracker": "https://github.com/Bitte-ein-Git/ha_rwfc/issues",
-  "version": "1.0.0",
   "iot_class": "cloud_polling",
-  "requirements": []
+  "issue_tracker": "https://github.com/Bitte-ein-Git/ha_rwfc/issues",
+  "requirements": [],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
### _fix_ › GitHub workflow `hassfest` manifest validation error:

> Manifest keys are not sorted correctly: domain, name, then alphabetical order

- This should resolve the _hassfest_ workflow failure.

<img width="240" height="240" alt="big brain" src="https://github.com/user-attachments/assets/ff125106-2ac2-4bc7-9939-7e6dd67f3c36" />
